### PR TITLE
Allow null facility NPIs

### DIFF
--- a/providers_schema.json
+++ b/providers_schema.json
@@ -44,7 +44,7 @@
         "facility": {
             "properties": {
                 "npi": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "pattern": "^[0-9]{10}$"
                 },
                 "type": {"type": "string", "enum": ["FACILITY"]},


### PR DESCRIPTION
Fix for error trying to validate a facility with a null NPI:

```
2 errors:

(root).0: must validate one and only one schema (oneOf)
(root).0.npi: must be of type string
```
